### PR TITLE
fix: invoke callbacks on value change, remove touchstart handler on unmount

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "mui-scrollable-slider-hook",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "lodash.debounce": "^4.0.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-scrollable-slider-hook",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Prevent slider value changes while scrolling vertically on touch devices",
   "main": "dist",
   "repository": {

--- a/src/hook/test.js
+++ b/src/hook/test.js
@@ -51,7 +51,6 @@ describe('useMuiScrollableSlider', () => {
       result.current.onChange(touchEndEvent, 25)
     })
 
-    expect(onChangeMock).toHaveBeenCalled()
     expect(result.current.value).toBe(20)
 
     act(() => {
@@ -72,7 +71,7 @@ describe('useMuiScrollableSlider', () => {
       result.current.onChangeCommitted(scrollTouchEvent, 75)
     })
 
-    expect(onChangeCommittedMock).toHaveBeenCalledWith(scrollTouchEvent, 75)
+    expect(onChangeCommittedMock).not.toHaveBeenCalledWith(scrollTouchEvent, 75)
     expect(result.current.value).toBe(30)
   })
 
@@ -93,6 +92,34 @@ describe('useMuiScrollableSlider', () => {
       result.current.onChangeCommitted(new MouseEvent('click'), 10)
     })
 
+    expect(result.current.value).toBe(10)
+  })
+
+  it('changes value at a pageY < delta when no touchstart touches', () => {
+    const { result } = renderHook(() => useMuiScrollableSlider())
+
+    act(() => {
+      mockEventTarget.dispatchEvent(
+        new TouchEvent('touchstart', {
+          changedTouches: []
+        })
+      )
+    })
+
+    act(() => {
+      result.current.onChangeCommitted(
+        new TouchEvent('touchend', { changedTouches: [{ pageY: 51 }] }),
+        10
+      )
+    })
+    expect(result.current.value).toBe(0)
+
+    act(() => {
+      result.current.onChangeCommitted(
+        new TouchEvent('touchend', { changedTouches: [{ pageY: 49 }] }),
+        10
+      )
+    })
     expect(result.current.value).toBe(10)
   })
 })


### PR DESCRIPTION
* Invoke `onChange` and `onChangeCommitted` only when the value of the slider will change
* Remove the `touchstart` event handler from the slider ref when unmounting